### PR TITLE
DXA-300 Replace deprecated GHA commands

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,7 +33,7 @@ jobs:
           else
             DOCKER_TAG="${GITHUB_REF:11}"
           fi
-          echo ::set-output name=tag::${DOCKER_TAG}
+          echo "tag=${DOCKER_TAG}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
# [DXA-300](https://immersivelabsuk.atlassian.net/browse/DXA-300)

This replaces the deprecated `::set-output` Actions command which will be disabled in May.


[DXA-300]: https://immersivelabsuk.atlassian.net/browse/DXA-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ